### PR TITLE
Add JSON_UNESCAPED_UNICODE as an option to the default Laravel json_encode

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -8,12 +8,6 @@ namespace Themsaid\Multilingual;
  */
 trait Translatable
 {
-    /**
-     * Set to false to avoid setting the json_encode as utf8
-     *
-     * @var bool
-     */
-    public $jsonAsUtf = true;
 
     /**
      * @param string $key
@@ -89,7 +83,11 @@ trait Translatable
      */
     protected function asJson($value)
     {
-        $mode = ( ! $this->jsonAsUtf) ? 0 : JSON_UNESCAPED_UNICODE;
+        $mode = JSON_UNESCAPED_UNICODE;
+        if (isset($this->jsonAsUtf) && $this->jsonAsUtf == false){
+            $mode = 0;
+        }
+
         return json_encode($value, $mode);
     }
 }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -2,8 +2,19 @@
 
 namespace Themsaid\Multilingual;
 
+/**
+ * Class Translatable
+ * @package Themsaid\Multilingual
+ */
 trait Translatable
 {
+    /**
+     * Set to false to avoid setting the json_encode as utf8
+     *
+     * @var bool
+     */
+    public $jsonAsUtf = true;
+
     /**
      * @param string $key
      * @return mixed
@@ -67,5 +78,18 @@ trait Translatable
         }
 
         return parent::isJsonCastable($key);
+    }
+
+    /**
+     * Alter default Laravel behaviour when it comes to json_encode.
+     * This will save the json as UTF-8 to the DB
+     *
+     * @param $value
+     * @return string
+     */
+    protected function asJson($value)
+    {
+        $mode = ( ! $this->jsonAsUtf) ? 0 : JSON_UNESCAPED_UNICODE;
+        return json_encode($value, $mode);
     }
 }


### PR DESCRIPTION
By default the Tranlsatable trait will apply the JSON_UNESCAPED_UNICODE  option to json_encode. Setting public $jsonAsUtf = false will fall back to the default Laravel behaviour
